### PR TITLE
fix: 도커 파일 내 파이썬 버전 수정

### DIFF
--- a/ufit/Dockerfile
+++ b/ufit/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
fix: 도커 파일 내 파이썬 버전 수정
python 3.11 => 3.13