### PR TITLE
feat: 요금제 데이터 수정 대응

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ pymongo
 langchain-anthropic>=0.3.0
 anthropic>=0.25.0
 langchain-mongodb>=0.1.1
+mongomock

--- a/ufit/main.py
+++ b/ufit/main.py
@@ -1,11 +1,16 @@
 from fastapi import FastAPI
-from ufit.routes.chat import chat_router  # 예: ufit/routes/sample.py 에서 가져오는 라우터
+from ufit.routes.chat import (
+    chat_router,
+)  # 예: ufit/routes/sample.py 에서 가져오는 라우터
 from ufit.routes.recommend_routes import recommend_router
+from ufit.routes.rateplan_routes import rateplan_router
 
 app = FastAPI()
 
 app.include_router(chat_router)
 app.include_router(recommend_router)
+app.include_router(rateplan_router)
+
 
 @app.get("/")
 def read_root():

--- a/ufit/routes/rateplan_routes.py
+++ b/ufit/routes/rateplan_routes.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Path
+from ufit.services.embedding_service import (
+    embed_single_rateplan,
+    delete_rateplan_vector,
+)
+
+router = APIRouter()
+
+
+@router.post("/api/admin/rateplans/{rateplan_id}")
+async def create_embedding_endpoint(rateplan_id: str = Path(...)):
+    # 벡터 임베딩
+    embed_single_rateplan(rateplan_id)
+
+    return {"message": "요금제 임베딩 등록 완료", "id": rateplan_id}
+
+
+@router.delete("/api/admin/rateplans/{rateplan_id}")
+async def delete_embedding_endpoint(rateplan_id: str = Path(...)):
+    delete_rateplan_vector(rateplan_id)
+
+    return {"message": "요금제 벡터 삭제 완료"}

--- a/ufit/routes/rateplan_routes.py
+++ b/ufit/routes/rateplan_routes.py
@@ -4,10 +4,10 @@ from ufit.services.embedding_service import (
     delete_rateplan_vector,
 )
 
-router = APIRouter()
+rateplan_router = APIRouter()
 
 
-@router.post("/api/admin/rateplans/{rateplan_id}")
+@rateplan_router.post("/api/admin/rateplans/{rateplan_id}")
 async def create_embedding_endpoint(rateplan_id: str = Path(...)):
     # 벡터 임베딩
     embed_single_rateplan(rateplan_id)
@@ -15,7 +15,7 @@ async def create_embedding_endpoint(rateplan_id: str = Path(...)):
     return {"message": "요금제 임베딩 등록 완료", "id": rateplan_id}
 
 
-@router.delete("/api/admin/rateplans/{rateplan_id}")
+@rateplan_router.delete("/api/admin/rateplans/{rateplan_id}")
 async def delete_embedding_endpoint(rateplan_id: str = Path(...)):
     delete_rateplan_vector(rateplan_id)
 

--- a/ufit/services/embedding_service.py
+++ b/ufit/services/embedding_service.py
@@ -1,0 +1,58 @@
+# embedding_service.py
+import os
+from pymongo import MongoClient
+from bson import ObjectId
+from langchain_core.documents import Document
+from langchain_openai import OpenAIEmbeddings
+from langchain_community.vectorstores.pgvector import PGVector
+from ufit.services.formatter import generate_final_output
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MONGODB_URI = os.getenv("MONGODB_URI")
+DB_NAME = "ufit"
+COLLECTION_NAME = "rate_plan"
+PGVECTOR_CONNECTION_STRING = os.getenv("PGVECTOR_CONNECTIONS_STRING")
+COLLECTION_NAME_VECTOR = "plans"
+
+mongo_client = MongoClient(MONGODB_URI)
+collection = mongo_client[DB_NAME][COLLECTION_NAME]
+
+
+# 테스트 시 덮어쓰기용 함수
+def set_mongo_collection(mock_collection):
+    global collection
+    collection = mock_collection
+
+
+embedding_model = OpenAIEmbeddings(model="text-embedding-3-small")
+vectorstore = PGVector(
+    embedding_function=embedding_model,
+    connection_string=PGVECTOR_CONNECTION_STRING,
+    collection_name=COLLECTION_NAME_VECTOR,
+)
+
+
+def embed_single_rateplan(rateplan_id: str):
+    plan = collection.find_one({"_id": ObjectId(rateplan_id)})
+    if not plan:
+        print(f" MongoDB에 해당 요금제 ID {rateplan_id} 없음")
+        return
+
+    doc = Document(
+        page_content=generate_final_output(plan),
+        metadata={
+            "mongo_id": str(plan["_id"]),
+            "plan_name": plan.get("plan_name", ""),
+            "idx": plan.get("idx", ""),
+        },
+    )
+
+    vectorstore.add_documents([doc])
+    print(f"요금제 {rateplan_id} 임베딩 완료")
+
+
+def delete_rateplan_vector(rateplan_id: str):
+    vectorstore.delete(filter={"mongo_id": rateplan_id})
+    print(f"요금제 {rateplan_id} 벡터 삭제 완료")

--- a/ufit/services/sync_embedding.py
+++ b/ufit/services/sync_embedding.py
@@ -1,0 +1,93 @@
+"""
+sync_embedding.py
+
+이 스크립트는 MongoDB에 저장된 요금제 데이터를 PGVector에 임베딩하여
+벡터 검색이 가능하도록 동기화하는 작업을 수행합니다.
+
+- MongoDB와 PGVector 벡터 저장소 간의 요금제 데이터 싱크 맞춤
+- 새로운 요금제가 MongoDB에 추가되었으면 → 벡터 임베딩 후 PGVector에 저장
+- MongoDB에서 삭제된 요금제가 있으면 → PGVector에서도 제거
+
+주의 ) 이 코드는 mongodb와 pgvector를 동기화하는 단발성 스크립트로 service, routes 코드와는 관계 없음
+"""
+
+import os
+from dotenv import load_dotenv
+from pymongo import MongoClient
+from langchain_openai import OpenAIEmbeddings
+from langchain_community.vectorstores.pgvector import PGVector
+from langchain_core.documents import Document
+from formatter import generate_final_output
+
+# 환경변수 로드
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+PGVECTOR_CONNECTION_STRING = os.getenv("PGVECTOR_CONNECTIONS_STRING")
+
+MONGODB_URI = os.getenv("MONGODB_URI")
+DB_NAME = "ufit"
+COLLECTION_NAME = "rate_plan"
+COLLECTION_NAME_VECTOR = "plans"
+
+os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
+
+# MongoDB 연결
+mongo_client = MongoClient(MONGODB_URI)
+collection = mongo_client[DB_NAME][COLLECTION_NAME]
+
+# MongoDB에서 요금제 전체 조회
+plans = list(collection.find({}))
+mongo_ids = set(str(plan["_id"]) for plan in plans)
+
+# 임베딩 모델
+embedding_model = OpenAIEmbeddings(model="text-embedding-3-small")
+
+# PGVector 초기화
+vectorstore = PGVector(
+    embedding_function=embedding_model,
+    connection_string=PGVECTOR_CONNECTION_STRING,
+    collection_name=COLLECTION_NAME_VECTOR,
+)
+
+# PGVector에서 저장된 모든 문서의 mongo_id 수집
+existing_docs = vectorstore.similarity_search("임시질문", k=10000)
+vector_mongo_ids = set(
+    doc.metadata.get("mongo_id")
+    for doc in existing_docs
+    if doc.metadata.get("mongo_id")
+)
+
+# 신규 삽입할 문서 필터링
+new_plans = [plan for plan in plans if str(plan["_id"]) not in vector_mongo_ids]
+
+# 제거할 문서 필터링 (MongoDB에는 없고 PGVector에만 있는 것)
+to_delete_ids = vector_mongo_ids - mongo_ids
+
+# 신규 문서 임베딩
+new_docs = [
+    Document(
+        page_content=generate_final_output(plan),
+        metadata={
+            "mongo_id": str(plan["_id"]),
+            "plan_name": plan.get("plan_name", ""),
+            "idx": plan.get("idx", ""),
+        },
+    )
+    for plan in new_plans
+]
+
+if new_docs:
+    vectorstore.add_documents(new_docs)
+    print(f"신규 임베딩: {len(new_docs)}건")
+else:
+    print("신규 요금제 없음 (모두 이미 임베딩됨)")
+
+# 삭제된 요금제 제거 (PGVector에만 있는 것)
+if to_delete_ids:
+    print(f"삭제할 요금제 {len(to_delete_ids)}건: PGVector에만 존재")
+
+    for mongo_id in to_delete_ids:
+        vectorstore.delete(filter={"mongo_id": mongo_id})
+    print("삭제 완료")
+else:
+    print("PGVector와 MongoDB 동기화 완료 - 삭제 항목 없음")

--- a/ufit/tests/test_rateplan_routes.py
+++ b/ufit/tests/test_rateplan_routes.py
@@ -1,0 +1,38 @@
+from fastapi.testclient import TestClient
+from ufit.main import app
+from ufit.services import embedding_service
+import mongomock
+from bson import ObjectId
+
+client = TestClient(app)
+
+
+def test_embedding_create_and_delete_with_mock():
+    # mongomock 설정
+    mock_client = mongomock.MongoClient()
+    mock_collection = mock_client["ufit"]["rate_plan"]
+    embedding_service.set_mongo_collection(mock_collection)
+
+    # 테스트 요금제 삽입
+    dummy_plan = {
+        "plan_name": "테스트 요금제",
+        "price": "33000",
+        "discount_price": "29700",
+        "data": "매달 5GB",
+        "summary": "테스트용 요금제입니다.",
+        "device_type": "LTE 태블릿",
+        "data_sharing": "불가능",
+        "social_category": "all",
+        "is_enabled": "TRUE",
+        "update_at": "2025-06-15",
+    }
+    inserted = mock_collection.insert_one(dummy_plan)
+    dummy_id = str(inserted.inserted_id)
+
+    # 벡터 임베딩 테스트
+    response = client.post(f"/api/admin/rateplans/{dummy_id}")
+    assert response.status_code == 200
+
+    # 벡터 삭제 테스트
+    delete_response = client.delete(f"/api/admin/rateplans/{dummy_id}")
+    assert delete_response.status_code == 200


### PR DESCRIPTION
## 🔥 Related Issue

- Close #19 


## 📑 Task

- MongoDB에 저장된 요금제(plan) 데이터를 불러와서 각 요금제마다 embedding을 생성하고 PGVector에 저장하며, MongoDB _id와 PGVector 데이터 간 매핑을 유지하였습니다.
-  langchain_pg_embedding의 cmetadata에 mongoDB의 요금제 Id를 추가하였습니다.
- 요금제 임베딩 생성 / 삭제 api 추가 
> api 경로는 같으며, post 요청일 경우 생성 / delete 요청일 경우 삭제 
> 두 api 모두 rateId를 받음

## 🔍 To Reviewer


