### PR TITLE
fix: default_factory에 lamba를 사용하도록 변경

### DIFF
--- a/ufit/models/rate_plan.py
+++ b/ufit/models/rate_plan.py
@@ -19,8 +19,12 @@ class RatePlan(BaseModel):
     is_enabled: bool
     is_deleted: bool
 
-    created_at: datetime = Field(default_factory=timezone.utc, alias="createdAt")
-    updated_at: datetime = Field(default_factory=timezone.utc, alias="updatedAt")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), alias="createdAt"
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), alias="updatedAt"
+    )
 
     class Config:
         populate_by_name = True


### PR DESCRIPTION
## 🔥 Related Issue

- Close #43


## 📑 Task

- `default_factory`는 **함수**를 요구하므로, 다음과 같이 `lambda`로 감싸 동적으로 값을 생성하도록 수정

```python
default_factory=lambda: datetime.now(timezone.utc)
```

## 🔍 To Reviewer

- 집중적으로 리뷰해야될 부분 있으면 작성
